### PR TITLE
Support for both currying and single calls

### DIFF
--- a/process/utils.lua
+++ b/process/utils.lua
@@ -1,18 +1,20 @@
 local utils = { _version = "0.0.1" }
 
 utils.curry = function (fn, argc)
-  argc = argc or debug.getinfo(fn, "u").nparams
+  argc = argc or {}
+  local currArgc = argc[1] or debug.getinfo(fn, "u").nparams
 
   return function (...)
     local args = {...}
 
-    if #args > argc then
+    if #args > currArgc then
       local res = fn
       local i = 1
 
       while type(res) == "function" do
-        res = res(args[i])
-        i = i + 1
+        currArgc = argc[i] or debug.getinfo(res, "u").nparams
+        res = res(table.unpack(args, i, i + currArgc))
+        i = i + currArgc
       end
 
       return res

--- a/process/utils.lua
+++ b/process/utils.lua
@@ -24,7 +24,7 @@ utils.curry = function (fn, argc)
   end
 end
 
-utils.concat = function (a)
+utils.concat = utils.curry(function (a)
   return function (b) 
     assert(type(a) == "table", "first argument should be a table that is an array")
     assert(type(b) == "table", "second argument should be a table that is an array")
@@ -37,9 +37,9 @@ utils.concat = function (a)
     end
     return result
   end
-end
+end, { 1, 1 })
 
-utils.reduce = function (fn)
+utils.reduce = utils.curry(function (fn)
   return function (initial)
     return function (t) 
       assert(type(fn) == "function", "first argument should be a function that accepts (result, value, key)")
@@ -55,9 +55,9 @@ utils.reduce = function (fn)
       return result
     end
   end
-end
+end, { 1, 1, 1 })
 
-utils.map = function (fn)
+utils.map = utils.curry(function (fn)
   assert(type(fn) == "function", "first argument should be a unary function")
 
   local function map (result, v, k)
@@ -66,9 +66,9 @@ utils.map = function (fn)
   end
 
   return utils.reduce(map)({})
-end
+end, { 1, 1 })
 
-utils.filter = function (fn)
+utils.filter = utils.curry(function (fn)
   assert(type(fn) == "function", "first argument should be a unary function")
 
   local function filter (result, v, _k)
@@ -79,9 +79,9 @@ utils.filter = function (fn)
   end
 
   return utils.reduce(filter)({})
-end
+end, { 1, 1 })
 
-utils.find = function (fn)
+utils.find = utils.curry(function (fn)
   return function (t)
     assert(type(fn) == "function", "first argument should be a unary function")
     assert(type(t) == "table", "second argument should be a table that is an array")
@@ -91,9 +91,9 @@ utils.find = function (fn)
       end
     end
   end
-end
+end, { 1, 1 })
 
-utils.propEq = function (propName)
+utils.propEq = utils.curry(function (propName)
   return function (value)
     return function (object)
       assert(type(propName) == "string", "first argument should be a string")
@@ -102,7 +102,7 @@ utils.propEq = function (propName)
       return object[propName] == value
     end
   end
-end
+end, { 1, 1, 1 })
 
 utils.compose = function(a,b) 
   return function (v) 
@@ -110,10 +110,10 @@ utils.compose = function(a,b)
   end
 end
 
-utils.prop = function (propName) 
+utils.prop = utils.curry(function (propName) 
   return function (object)
     return object[propName]
   end
-end
+end, { 1, 1 })
 
 return utils

--- a/process/utils.lua
+++ b/process/utils.lua
@@ -1,5 +1,27 @@
 local utils = { _version = "0.0.1" }
 
+utils.curry = function (fn, argc)
+  argc = argc or debug.getinfo(fn, "u").nparams
+
+  return function (...)
+    local args = {...}
+
+    if #args > argc then
+      local res = fn
+      local i = 1
+
+      while type(res) == "function" do
+        res = res(args[i])
+        i = i + 1
+      end
+
+      return res
+    end
+
+    return fn(table.unpack(args))
+  end
+end
+
 utils.concat = function (a)
   return function (b) 
     assert(type(a) == "table", "first argument should be a table that is an array")

--- a/process/utils.lua
+++ b/process/utils.lua
@@ -1,75 +1,96 @@
 local utils = { _version = "0.0.1" }
 
-utils.curry = function (fn, argc)
-  argc = argc or {}
-  local currArgc = argc[1] or debug.getinfo(fn, "u").nparams
+local function isArray(table)
+  if type(table) == "table" then
+      local maxIndex = 0
+      for k, v in pairs(table) do
+          if type(k) ~= "number" or k < 1 or math.floor(k) ~= k then
+              return false -- If there's a non-integer key, it's not an array
+          end
+          maxIndex = math.max(maxIndex, k)
+      end
+      -- If the highest numeric index is equal to the number of elements, it's an array
+      return maxIndex == #table
+  end
+  return false
+end
+
+-- @param {function} fn
+-- @param {number} arity
+utils.curry = function (fn, arity)
+  assert(type(fn) == "function", "function is required as first argument")
+  arity = arity or debug.getinfo(fn, "u").nparams
+  if arity < 2 then return fn end
 
   return function (...)
     local args = {...}
 
-    if #args > currArgc then
-      local res = fn
-      local i = 1
-
-      while type(res) == "function" do
-        currArgc = argc[i] or debug.getinfo(res, "u").nparams
-        res = res(table.unpack(args, i, i + currArgc))
-        i = i + currArgc
-      end
-
-      return res
+    if #args >= arity then
+      return fn(table.unpack(args))
+    else
+      return utils.curry(function (...)
+        return fn(table.unpack(args),  ...)
+      end, arity - #args)
     end
-
-    return fn(table.unpack(args))
   end
 end
 
-utils.concat = utils.curry(function (a)
-  return function (b) 
-    assert(type(a) == "table", "first argument should be a table that is an array")
-    assert(type(b) == "table", "second argument should be a table that is an array")
-    local result = {}
-    for i = 1, #a do
-        result[#result + 1] = a[i]
-    end
-    for i = 1, #b do
-        result[#result + 1] = b[i]
-    end
-    return result
-  end
-end, { 1, 1 })
+--- Concat two Array Tables.
+-- @param {table<Array>} a
+-- @param {table<Array>} b
+utils.concat = utils.curry(function (a, b)
+  assert(type(a) == "table", "first argument should be a table that is an array")
+  assert(type(b) == "table", "second argument should be a table that is an array")
+  assert(isArray(a), "first argument should be a table")
+  assert(isArray(b), "second argument should be a table")
 
-utils.reduce = utils.curry(function (fn)
-  return function (initial)
-    return function (t) 
-      assert(type(fn) == "function", "first argument should be a function that accepts (result, value, key)")
-      assert(type(t) == "table", "second argument should be a table that is an array")
-      local result = initial
-      for k, v in pairs(t) do
-        if result == nil then
-          result = v
-        else
-          result = fn(result, v, k)
-        end
-      end
-      return result
+  local result = {}
+  for i = 1, #a do
+      result[#result + 1] = a[i]
+  end
+  for i = 1, #b do
+      result[#result + 1] = b[i]
+  end
+  return result
+end, 2)
+
+--- reduce applies a function to a table
+-- @param {function} fn
+-- @param {any} initial
+-- @param {table<Array>} t
+utils.reduce = utils.curry(function (fn, initial, t)
+  assert(type(fn) == "function", "first argument should be a function that accepts (result, value, key)")
+  assert(type(t) == "table" and isArray(t), "third argument should be a table that is an array")
+  local result = initial
+  for k, v in pairs(t) do
+    if result == nil then
+      result = v
+    else
+      result = fn(result, v, k)
     end
   end
-end, { 1, 1, 1 })
+  return result
+end, 3)
 
-utils.map = utils.curry(function (fn)
+-- @param {function} fn
+-- @param {table<Array>} data
+utils.map = utils.curry(function (fn, data)
   assert(type(fn) == "function", "first argument should be a unary function")
+  assert(type(data) == "table" and isArray(data), "second argument should be an Array")
 
   local function map (result, v, k)
     result[k] = fn(v)
     return result
   end
 
-  return utils.reduce(map)({})
-end, { 1, 1 })
+  return utils.reduce(map, {}, data)
+end, 2)
 
-utils.filter = utils.curry(function (fn)
+-- @param {function} fn
+-- @param {table<Array>} data
+utils.filter = utils.curry(function (fn, data)
   assert(type(fn) == "function", "first argument should be a unary function")
+  assert(type(data) == "table" and isArray(data), "second argument should be an Array")
 
   local function filter (result, v, _k)
     if fn(v) then
@@ -78,42 +99,44 @@ utils.filter = utils.curry(function (fn)
     return result
   end
 
-  return utils.reduce(filter)({})
-end, { 1, 1 })
+  return utils.reduce(filter,{}, data)
+end, 2)
 
-utils.find = utils.curry(function (fn)
-  return function (t)
-    assert(type(fn) == "function", "first argument should be a unary function")
-    assert(type(t) == "table", "second argument should be a table that is an array")
-    for _, v in pairs(t) do
-      if fn(v) then
-        return v
-      end
+-- @param {function} fn
+-- @param {table<Array>} t
+utils.find = utils.curry(function (fn, t)
+  assert(type(fn) == "function", "first argument should be a unary function")
+  assert(type(t) == "table", "second argument should be a table that is an array")
+  for _, v in pairs(t) do
+    if fn(v) then
+      return v
     end
   end
-end, { 1, 1 })
+end, 2)
 
-utils.propEq = utils.curry(function (propName)
-  return function (value)
-    return function (object)
-      assert(type(propName) == "string", "first argument should be a string")
-      assert(type(value) == "string", "second argument should be a string")
-      assert(type(object) == "table", "third argument should be a table<object>")
-      return object[propName] == value
-    end
-  end
-end, { 1, 1, 1 })
+-- @param {string} propName
+-- @param {string} value 
+-- @param {table} object
+utils.propEq = utils.curry(function (propName, value, object)
+  assert(type(propName) == "string", "first argument should be a string")
+  -- assert(type(value) == "string", "second argument should be a string")
+  assert(type(object) == "table", "third argument should be a table<object>")
+  
+  return object[propName] == value
+end, 3)
 
-utils.compose = function(a,b) 
+-- @param {function} a
+-- @param {function} b
+utils.compose = utils.curry(function(a,b) 
   return function (v) 
     return a(b(v))
   end
-end
+end, 2)
 
-utils.prop = utils.curry(function (propName) 
-  return function (object)
-    return object[propName]
-  end
-end, { 1, 1 })
+-- @param {string} propName
+-- @param {table} object
+utils.prop = utils.curry(function (propName, object) 
+  return object[propName]
+end, 2)
 
 return utils

--- a/process/utils.test.js
+++ b/process/utils.test.js
@@ -9,36 +9,36 @@ async function test() {
   let response = await handle(null, {
     Target: "PROCESS",
     Tags: [
-      { name: 'function', value: 'eval' },
-      {
-        name: 'expression', value: `
-utils.find(
-  utils.propEq("name")("expression")
-)({{name="expression", value = "beep"}})
-      `}
-    ]
-  }, { Process: { Id: 'FOO' } })
-  //console.log(response.output)
+      { name: 'Action', value: 'Eval' },
+    ],
+    Data: `
+return Utils.find(
+  Utils.propEq("name")("expression"))
+  ({{name = "expression", value = "beep" }}
+)
+    `
+  }, { Process: { Id: 'FOO', Tags: [] } })
+  //console.log(response.Output)
   assert.equal(response.Output.data.output.value, 'beep')
 
   let response2 = await handle(null, {
     Target: "PROCESS",
     Tags: [
-      { name: 'function', value: 'eval' },
-      {
-        name: 'expression', value: `
-utils.map(
-  function (v)
-    v.value = "boom"
-    return v
-  end)({
-    {name="expression", value = "beep"}, 
-    {name="what", value = "beep"}, 
-    {name="right", value = "beep"}
-  })
-      `}
-    ]
-  }, { Process: { Id: 'FOO' } })
+      { name: 'Action', value: 'Eval' }
+    ],
+    Data: `
+    Utils.map(
+      function (v)
+        v.value = "boom"
+        return v
+      end)({
+        {name="expression", value = "beep"}, 
+        {name="what", value = "beep"}, 
+        {name="right", value = "beep"}
+      })
+          `
+  }, { Process: { Id: 'FOO', Tags: [] } })
+
   assert.deepStrictEqual(response2.Output.data.output, [
     { name: 'expression', value: 'boom' },
     { name: 'what', value: 'boom' },
@@ -48,24 +48,24 @@ utils.map(
   let response3 = await handle(null, {
     Target: "PROCESS",
     Tags: [
-      { name: 'function', value: 'eval' },
-      {
-        name: 'expression', value: `
-utils.filter(
-  function (v)
-    return v.value == 'beep'
-  end)({
-    {name="expression", value = "beep"}, 
-    {name="what", value = "boop"}, 
-    {name="right", value = "beep"}
-  })
-      `}
-    ]
-  }, { Process: { Id: 'FOO' } })
+      { name: 'Action', value: 'Eval' }
+    ],
+    Data: `
+     Utils.filter(
+      function (v)
+        return v.value == 'beep'
+      end)({
+        {name="expression", value = "beep"}, 
+        {name="what", value = "boop"}, 
+        {name="right", value = "beep"}
+      })
+          `
+  }, { Process: { Id: 'FOO', Tags: [] } })
   assert.deepStrictEqual(response3.Output.data.output, [
     { name: 'expression', value: 'beep' },
     { name: 'right', value: 'beep' }
   ])
+
 }
 
 test()


### PR DESCRIPTION
This PR makes table utility functions work with single calls, while also allowing currying:
```lua
...
local add = function (a) 
  return function (b)
    return a + b
  end
end
local curryAdd = utils.curry(add, { 1, 1 })

assert(curryAdd(1, 3) == 4)
assert(curryAdd(1)(3) == 4)
...
```