### PR TITLE
Support absolute paths for ".load"

### DIFF
--- a/src/commands/load.js
+++ b/src/commands/load.js
@@ -6,11 +6,15 @@ export function load(line) {
   // get filename
   let fn = line.split(' ')[1]
   if (/\.lua$/.test(fn)) {
-    if (!fs.existsSync(path.resolve(process.cwd() + '/' + fn))) {
+    let filePath = fn;
+    if (!path.isAbsolute(filePath)) {
+      filePath = path.resolve(path.join(process.cwd(), fn))
+    }
+    if (!fs.existsSync(filePath)) {
       throw Error(chalk.red('ERROR: file not found.'));
     }
     console.log(chalk.green('Loading... ', fn));
-    line = fs.readFileSync(path.resolve(process.cwd() + '/' + fn), 'utf-8');
+    line = fs.readFileSync(filePath, 'utf-8');
     return line
   } else {
     throw Error(chalk.red('ERROR: .load function requires a *.lua file'))


### PR DESCRIPTION
This PR allows users to `.load` a file that is not in the workspace that aos runs in. For instance:
```
.load /Users/marton/Desktop/Projects/my-project/test.lua
```
