### PR TITLE
feat: add ao.unset sentinel for patch field removal

### DIFF
--- a/process/ao.lua
+++ b/process/ao.lua
@@ -43,7 +43,8 @@ local ao = {
         'Pushed-For', 'Read-Only', 'Cron', 'Block-Height', 'Reference', 'Id',
         'Reply-To'
     },
-    Nonce = nil
+    Nonce = nil,
+    unset = "__ao-unset__"
 }
 
 --- Checks if a key exists in a list.


### PR DESCRIPTION
Adds `ao.unset = "__ao-unset__"` to the ao table. Used with `patch@1.0` to remove fields from nested maps.

Companion to permaweb/HyperBEAM#829.