### PR TITLE
fix: bundling moved runtime code from src to dist

### DIFF
--- a/src/commands/blueprints.js
+++ b/src/commands/blueprints.js
@@ -1,14 +1,12 @@
 import fs from 'fs'
 import path from 'path'
-import * as url from 'url'
+import { packageRoot } from '../package-root.js'
 import { chalk } from '../utils/colors.js'
-
-const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 
 export function loadBlueprint(line) {
   let name = line.split(' ')[1]
-  const luaFile = __dirname + '../../blueprints/' + name + '.lua'
-  if (fs.existsSync(path.resolve(luaFile))) {
+  const luaFile = path.join(packageRoot, 'blueprints', `${name}.lua`)
+  if (fs.existsSync(luaFile)) {
     const code = fs.readFileSync(luaFile, 'utf-8')
     console.log(chalk.green('Loading... ', name))
     return code

--- a/src/commands/os.js
+++ b/src/commands/os.js
@@ -7,14 +7,8 @@
  */
 import fs from 'node:fs'
 import path from 'node:path'
-import os from 'node:os'
-import * as url from 'url'
+import { packageRoot } from '../package-root.js'
 import { chalk } from '../utils/colors.js'
-
-let __dirname = url.fileURLToPath(new URL('.', import.meta.url))
-if (os.platform() === 'win32') {
-  __dirname = __dirname.replace(/\\/g, '/').replace(/^[A-Za-z]:\//, '/')
-}
 
 export function dry() {
   console.log('not implemented')
@@ -36,7 +30,7 @@ export function update() {
     'process.lua'
   ]
     .map(name => {
-      const code = fs.readFileSync(__dirname + '../../process/' + name, 'utf-8')
+      const code = fs.readFileSync(path.join(packageRoot, 'process', name), 'utf-8')
       const mod = name.replace(/\.lua$/, '')
       return template(mod, code)
     })

--- a/src/package-root.js
+++ b/src/package-root.js
@@ -1,0 +1,23 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export const packageRoot = findPackageRoot(path.dirname(fileURLToPath(import.meta.url)))
+
+function findPackageRoot(startDirectory) {
+  let directory = startDirectory
+
+  while (true) {
+    if (fs.existsSync(path.join(directory, 'package.json'))) {
+      return directory
+    }
+
+    const parent = path.dirname(directory)
+
+    if (parent === directory) {
+      throw new Error(`Unable to find the AOS package root from ${startDirectory}`)
+    }
+
+    directory = parent
+  }
+}

--- a/src/services/blueprints.js
+++ b/src/services/blueprints.js
@@ -1,23 +1,17 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import os from 'node:os'
-import * as url from 'url'
+import { packageRoot } from '../package-root.js'
 import { chalk } from '../utils/colors.js'
-
-let __dirname = url.fileURLToPath(new URL('.', import.meta.url))
-if (os.platform() === 'win32') {
-  __dirname = __dirname.replace(/\\/g, '/').replace(/^[A-Za-z]:\//, '/')
-}
 
 export function blueprints(dir) {
   try {
-    const blueprintsDir = __dirname + '../../blueprints'
+    const blueprintsDir = path.join(packageRoot, 'blueprints')
     const outputDir = process.cwd() + '/' + (dir === true ? '' : dir)
 
-    let prints = fs.readdirSync(path.resolve(blueprintsDir))
+    let prints = fs.readdirSync(blueprintsDir)
     prints
       .map(n => {
-        return [n, fs.readFileSync(path.resolve(blueprintsDir + '/' + n), 'utf-8')]
+        return [n, fs.readFileSync(path.join(blueprintsDir, n), 'utf-8')]
       })
       .map(([n, lua]) => {
         fs.writeFileSync(path.resolve(outputDir + '/' + n), lua)

--- a/src/services/get-pkg.js
+++ b/src/services/get-pkg.js
@@ -1,15 +1,8 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import os from 'node:os'
-import * as url from 'url'
+import { packageRoot } from '../package-root.js'
 
-let __dirname = url.fileURLToPath(new URL('.', import.meta.url))
-
-if (os.platform() === 'win32') {
-  __dirname = __dirname.replace(/\\/g, '/')
-}
-
-const pkg = JSON.parse(fs.readFileSync(path.resolve(__dirname + '../../package.json')))
+const pkg = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf-8'))
 
 export function getPkg() {
   return pkg


### PR DESCRIPTION
## Version Update

Select exactly one version update type. This choice is used by CI after the PR is merged into
`main` to update `package.json`, create the release tag, and publish the package to npm.

- [ ] major
- [ ] minor
- [x] patch
